### PR TITLE
devdependencies everything

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,35 +20,35 @@
     "url": "https://github.com/ponciusz/icomoon-react.git"
   },
   "devDependencies": {
-    "babel-eslint": "^10.0.1",
-    "babel-loader": "^8.0.5",
-    "eslint": "^6.2.2",
-    "eslint-plugin-react": "^7.14.3",
-    "html-webpack-plugin": "^3.2.0",
-    "jest": "^24.9.0",
-    "path": "^0.12.7",
-    "ts-jest": "^24.0.2",
-    "webpack": "^4.39.3",
-    "webpack-cli": "^3.3.7",
-    "webpack-dev-server": "^3.8.0"
-  },
-  "dependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
     "@types/jest": "^24.0.18",
     "@types/react-dom": "^16.9.0",
+    "babel-eslint": "^10.0.1",
+    "babel-loader": "^8.0.5",
     "coveralls": "^3.0.3",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.10.0",
+    "eslint": "^6.2.2",
+    "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-babel": "^5.3.0",
-    "husky": "^3.0.4",
-    "lint-staged": "^9.2.5",
     "prettier-eslint-cli": "^5.0.0",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
+    "html-webpack-plugin": "^3.2.0",
+    "husky": "^3.0.4",
+    "jest": "^24.9.0",
+    "lint-staged": "^9.2.5",
+    "path": "^0.12.7",
+    "ts-jest": "^24.0.2",
     "ts-loader": "^6.0.4",
-    "typescript": "^3.6.2"
+    "typescript": "^3.6.2",
+    "webpack": "^4.39.3",
+    "webpack-cli": "^3.3.7",
+    "webpack-dev-server": "^3.8.0"
+  },
+  "dependencies": {
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
   }
 }


### PR DESCRIPTION
As discussed on #42, `icomoon-react` is installing husky and a lot of other packages as a dependency on any project that uses it. Husky is particularly a problem because this will overwrite the pre-commit configurations these projects that depend on icomoon-react uses.

#42 