### PR TITLE
chore: add src to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src
 public
 images
 .babelrc


### PR DESCRIPTION
`src` directory must be added to enable sourcemaps to work properly. Otherwise there is an error like following:

```
Failed to parse source map from '[...]/node_modules/icomoon-react/src/index.ts' file:
	Error: ENOENT: no such file or directory, open '[...]/node_modules/icomoon-react/src/index.ts'
```